### PR TITLE
Add confidence threshold filter for auto-markup

### DIFF
--- a/backend/api_datasets.py
+++ b/backend/api_datasets.py
@@ -425,6 +425,22 @@ def get_next_batch(dataset_id: int, limit: int = Query(100, ge=1, le=1000)):
                 detail="для этого датасета уже есть активный batch"
             )
 
+        # Confidence filter: images where all boxes >= threshold are auto-accepted as GT
+        config = session.query(TrainingConfig).filter(TrainingConfig.dataset_id == dataset_id).first()
+        conf_filter_enabled = config.augmentation_enabled if config else False
+        conf_threshold = float(config.augmentation_threshold) if config else 0.85
+
+        boxes_by_filename = {img["filename"]: img["boxes"] for img in images_payload}
+        auto_accepted_set: set[str] = set()
+        review_list: list[str] = []
+
+        for filename in image_filenames:
+            boxes = boxes_by_filename.get(filename, [])
+            if conf_filter_enabled and boxes and all(b["confidence"] >= conf_threshold for b in boxes):
+                auto_accepted_set.add(filename)
+            else:
+                review_list.append(filename)
+
         existing_images = {
             row.filename: row
             for row in session.query(DatasetImage).filter(
@@ -432,6 +448,9 @@ def get_next_batch(dataset_id: int, limit: int = Query(100, ge=1, le=1000)):
                 DatasetImage.filename.in_(image_filenames)
             ).all()
         }
+
+        ready_status = session.query(ImageStatus).filter(ImageStatus.code == "ready_for_training").first()
+        ready_status_id = ready_status.id if ready_status else 3
 
         for filename in image_filenames:
             image_path = os.path.join(dataset_path, filename)
@@ -442,11 +461,12 @@ def get_next_batch(dataset_id: int, limit: int = Query(100, ge=1, le=1000)):
                 os.path.splitext(filename)[0] + ".txt"
             )
             row = existing_images.get(filename)
+            target_status_id = ready_status_id if filename in auto_accepted_set else 4
             if row:
                 row.image_path = image_path
                 row.label_path = label_path
-                if row.status_id == 1:
-                    row.status_id = 4
+                if row.status_id in (1, 4):
+                    row.status_id = target_status_id
             else:
                 session.add(
                     DatasetImage(
@@ -454,41 +474,77 @@ def get_next_batch(dataset_id: int, limit: int = Query(100, ge=1, le=1000)):
                         filename=filename,
                         image_path=image_path,
                         label_path=label_path,
-                        status_id=4,
+                        status_id=target_status_id,
                     )
                 )
 
-        batch = PredictionBatch(
-            dataset_id=dataset_id,
-            model_version_id=model_version_id,
-            architecture=architecture,
-            status="active",
-            image_filenames_json=json.dumps(image_filenames),
-        )
-        session.add(batch)
         session.flush()
 
+        # Re-fetch to get IDs for newly inserted rows
+        all_images_in_db = {
+            row.filename: row
+            for row in session.query(DatasetImage).filter(
+                DatasetImage.dataset_id == dataset_id,
+                DatasetImage.filename.in_(image_filenames)
+            ).all()
+        }
+
+        # Save boxes for auto-accepted images as GT (linked via dataset_image_id, no batch)
         for box in snapshot_boxes:
-            session.add(
-                PredictionBox(
-                    batch_id=batch.id,
-                    image_filename=box["image_filename"],
-                    class_id=box["class_id"],
-                    confidence=box["confidence"],
-                    x1=box["x1"],
-                    y1=box["y1"],
-                    x2=box["x2"],
-                    y2=box["y2"],
+            if box["image_filename"] in auto_accepted_set:
+                img_row = all_images_in_db.get(box["image_filename"])
+                session.add(
+                    PredictionBox(
+                        dataset_image_id=img_row.id if img_row else None,
+                        image_filename=box["image_filename"],
+                        class_id=box["class_id"],
+                        confidence=box["confidence"],
+                        x1=box["x1"],
+                        y1=box["y1"],
+                        x2=box["x2"],
+                        y2=box["y2"],
+                    )
                 )
+
+        # Create batch only for images that need user review
+        batch_id = None
+        review_images_payload = [img for img in images_payload if img["filename"] in set(review_list)]
+        review_snapshot_boxes = [b for b in snapshot_boxes if b["image_filename"] in set(review_list)]
+
+        if review_list:
+            batch = PredictionBatch(
+                dataset_id=dataset_id,
+                model_version_id=model_version_id,
+                architecture=architecture,
+                status="active",
+                image_filenames_json=json.dumps(review_list),
             )
+            session.add(batch)
+            session.flush()
+
+            for box in review_snapshot_boxes:
+                session.add(
+                    PredictionBox(
+                        batch_id=batch.id,
+                        image_filename=box["image_filename"],
+                        class_id=box["class_id"],
+                        confidence=box["confidence"],
+                        x1=box["x1"],
+                        y1=box["y1"],
+                        x2=box["x2"],
+                        y2=box["y2"],
+                    )
+                )
+
+            batch_id = batch.id
 
         session.commit()
-        batch_id = batch.id
 
     return {
         "batch_id": batch_id,
         "dataset_id": dataset_id,
-        "images": images_payload,
+        "images": review_images_payload,
+        "auto_accepted_count": len(auto_accepted_set),
     }
 
 

--- a/frontend/css/workPage/sectionWorkSpaceMain.css
+++ b/frontend/css/workPage/sectionWorkSpaceMain.css
@@ -74,7 +74,7 @@
 
 .section-workspace__auto-markup-box {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 8px;
   padding: 8px 12px;
   background: rgba(255, 255, 255, 0.03);
@@ -82,10 +82,77 @@
   border-radius: 8px;
 }
 
+.section-workspace__auto-markup-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .section-workspace__auto-markup-box label {
   color: #94A3B8;
   font-size: 13px;
   white-space: nowrap;
+}
+
+.section-workspace__conf-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 6px;
+  border-top: 1px solid #1E293B;
+}
+
+.section-workspace__conf-filter-label {
+  display: flex !important;
+  align-items: center;
+  gap: 6px;
+  color: #94A3B8;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.section-workspace__conf-filter-label input[type="checkbox"] {
+  accent-color: #6366F1;
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+}
+
+.section-workspace__conf-filter-controls {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.section-workspace__conf-filter-input {
+  width: 70px;
+  height: 30px;
+  padding: 4px 8px;
+  background: #1E293B;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 13px;
+  outline: none;
+}
+
+.section-workspace__conf-filter-input:focus {
+  border-color: #6366F1;
+}
+
+.section-workspace__toolbar-server-button--save-threshold {
+  background-color: #6366F1;
+  color: #fff;
+  font-weight: 600;
+  padding: 0 14px;
+  height: 30px;
+  font-size: 13px;
+}
+
+.section-workspace__toolbar-server-button--save-threshold:hover {
+  background-color: #4F46E5;
 }
 
 .section-workspace__auto-markup-input {

--- a/frontend/js/work.js
+++ b/frontend/js/work.js
@@ -346,9 +346,10 @@ document.querySelector('.section-workspace__toolbar-server-button--auto-markup')
     const imagesToProcess = images.slice(0, Math.min(count, images.length));
     
     Notify.success(`Начинаем авторазметку ${imagesToProcess.length} изображений...`);
-    
+
     let successCount = 0;
     let errorCount = 0;
+    let autoAcceptedCount = 0;
     
     // Process each image
     for (const img of imagesToProcess) {
@@ -386,24 +387,36 @@ document.querySelector('.section-workspace__toolbar-server-button--auto-markup')
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(detections)
         });
-        
+
         if (!saveRes.ok) {
           console.error(`Save failed for ${img.filename}:`, saveRes.status);
           errorCount++;
           continue;
         }
-        
-        const saveResult = await saveRes.json();
-        console.log(`Saved ${saveResult.count} detections for ${img.filename}`);
+
+        // Auto-accept if all boxes pass the confidence threshold
+        const allAboveThreshold = detections.length > 0 &&
+          detections.every(d => d.conf >= confFilterThreshold);
+
+        if (confFilterEnabled && allAboveThreshold) {
+          const acceptRes = await fetch(`http://localhost:8000/api/images/${img.id}/accept`, { method: 'POST' });
+          if (acceptRes.ok) {
+            autoAcceptedCount++;
+          }
+        }
+
         successCount++;
-        
+
       } catch (err) {
         console.error(`Error processing ${img.filename}:`, err);
         errorCount++;
       }
     }
     
-    Notify.success(`Авторазметка завершена!\nУспешно: ${successCount}\nОшибок: ${errorCount}`);
+    const autoMsg = (confFilterEnabled && autoAcceptedCount > 0)
+      ? `\nАвтопринято как GT: ${autoAcceptedCount}`
+      : '';
+    Notify.success(`Авторазметка завершена!\nУспешно: ${successCount}${autoMsg}\nОшибок: ${errorCount}`);
     
     // Reload current category to show updated images
     loadImagesForCategory();
@@ -467,7 +480,61 @@ document.querySelector('.section-workspace__decision-button--reject')?.addEventL
   }
 });
 
+// Confidence filter settings
+let confFilterEnabled = false;
+let confFilterThreshold = 0.85;
+
+async function loadConfFilterConfig() {
+  try {
+    const res = await fetch(`http://localhost:8000/api/datasets/${dataset.id}/augmentation`);
+    if (!res.ok) return;
+    const data = await res.json();
+    confFilterEnabled = data.augmentation_enabled ?? false;
+    confFilterThreshold = data.augmentation_threshold ?? 0.85;
+
+    const checkbox = document.getElementById('conf-filter-enabled');
+    const thresholdInput = document.getElementById('conf-filter-threshold');
+    if (checkbox) checkbox.checked = confFilterEnabled;
+    if (thresholdInput) thresholdInput.value = confFilterThreshold;
+    updateConfFilterControlsVisibility();
+  } catch (err) {
+    console.error('Failed to load conf filter config:', err);
+  }
+}
+
+function updateConfFilterControlsVisibility() {
+  const controls = document.getElementById('conf-filter-controls');
+  if (controls) controls.style.display = confFilterEnabled ? 'flex' : 'none';
+}
+
+document.getElementById('conf-filter-enabled')?.addEventListener('change', (e) => {
+  confFilterEnabled = e.target.checked;
+  updateConfFilterControlsVisibility();
+});
+
+document.getElementById('conf-filter-save')?.addEventListener('click', async () => {
+  const thresholdInput = document.getElementById('conf-filter-threshold');
+  const threshold = parseFloat(thresholdInput?.value);
+  if (isNaN(threshold) || threshold < 0 || threshold > 1) {
+    Notify.error('Порог должен быть числом от 0 до 1');
+    return;
+  }
+  confFilterThreshold = threshold;
+  try {
+    const res = await fetch(`http://localhost:8000/api/datasets/${dataset.id}/augmentation`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ augmentation_enabled: confFilterEnabled, augmentation_threshold: confFilterThreshold })
+    });
+    if (!res.ok) throw new Error(`HTTP error: ${res.status}`);
+    Notify.success('Настройки порога сохранены');
+  } catch (err) {
+    Notify.error('Ошибка при сохранении настроек');
+  }
+});
+
 // Initialize
+loadConfFilterConfig();
 updateCategory();
 
 // Expose DetectionOverlay for backward compatibility

--- a/frontend/pages/work.html
+++ b/frontend/pages/work.html
@@ -87,17 +87,40 @@
             </div>
             <div class="section-workspace__toolbar-server-actions">
               <div class="section-workspace__auto-markup-box">
-                <label for="auto-markup-count">Разметить автоматически:</label>
-                <input 
-                  type="number" 
-                  id="auto-markup-count" 
-                  min="1" 
-                  placeholder="Кол-во"
-                  class="section-workspace__auto-markup-input"
-                />
-                <button class="section-workspace__toolbar-server-button section-workspace__toolbar-server-button--auto-markup">
-                  Запустить
-                </button>
+                <div class="section-workspace__auto-markup-row">
+                  <label for="auto-markup-count">Разметить автоматически:</label>
+                  <input
+                    type="number"
+                    id="auto-markup-count"
+                    min="1"
+                    placeholder="Кол-во"
+                    class="section-workspace__auto-markup-input"
+                  />
+                  <button class="section-workspace__toolbar-server-button section-workspace__toolbar-server-button--auto-markup">
+                    Запустить
+                  </button>
+                </div>
+                <div class="section-workspace__conf-filter">
+                  <label class="section-workspace__conf-filter-label">
+                    <input type="checkbox" id="conf-filter-enabled" />
+                    Автопринятие по порогу уверенности
+                  </label>
+                  <div class="section-workspace__conf-filter-controls" id="conf-filter-controls">
+                    <label for="conf-filter-threshold">Порог (0–1):</label>
+                    <input
+                      type="number"
+                      id="conf-filter-threshold"
+                      min="0"
+                      max="1"
+                      step="0.01"
+                      value="0.85"
+                      class="section-workspace__conf-filter-input"
+                    />
+                    <button id="conf-filter-save" class="section-workspace__toolbar-server-button section-workspace__toolbar-server-button--save-threshold">
+                      Сохранить
+                    </button>
+                  </div>
+                </div>
               </div>
               <button
                 class="section-workspace__toolbar-server-button section-workspace__toolbar-server-button--recheck"


### PR DESCRIPTION
Add confidence threshold auto-accept filter for auto-markup

Introduce a configurable confidence threshold that reduces manual
annotation work during auto-markup:

- Images where all predicted boxes have confidence >= threshold are
  automatically accepted as ground truth (ready_for_training) and
  skipped in the user's review queue
- Images with at least one box below the threshold are sent to the
  user for manual review as usual
- Images with no detections always go to the user for review
- Feature can be enabled/disabled by the user (their responsibility)
- Threshold and enabled state are persisted via existing
  PUT /api/datasets/{id}/augmentation endpoint
- Logic applied in both get_next_batch (backend) and the
  per-image auto-markup flow (frontend)

